### PR TITLE
windows: using mac_address's windows code to handle align issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@ mod os;
 #[path = "linux.rs"]
 mod os;
 
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+#[path = "other.rs"]
+mod os;
+
 pub use os::get_mac;
 
 pub type ResultType<F, E = anyhow::Error> = anyhow::Result<F, E>;
@@ -16,6 +20,20 @@ pub type ResultType<F, E = anyhow::Error> = anyhow::Result<F, E>;
 pub struct MacInfo {
     pub name: String,
     pub addr: String,
+}
+
+#[allow(unused)]
+pub(crate) fn is_valid_mac(mac: &str) -> bool {
+    if mac.len() != 17 {
+        return false;
+    }
+    let bytes: Vec<&str> = mac.split(':').collect();
+    if bytes.len() != 6 {
+        return false;
+    }
+    bytes
+        .iter()
+        .all(|byte| byte.len() == 2 && byte.chars().all(|c| c.is_ascii_hexdigit()))
 }
 
 mod test {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use regex::Regex;
 use std::process::Command;
 
@@ -35,6 +35,10 @@ pub fn get_mac() -> ResultType<MacInfo> {
             .as_str()
             .to_string()
     };
+
+    if !crate::is_valid_mac(&addr) {
+        bail!("Invalid MAC address format: {}", addr);
+    }
 
     Ok(MacInfo {
         name: interface.to_string(),

--- a/src/other.rs
+++ b/src/other.rs
@@ -1,0 +1,6 @@
+use crate::{MacInfo, ResultType};
+use anyhow::bail;
+
+pub fn get_mac() -> ResultType<MacInfo> {
+    bail!("not implemented");
+}

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,108 +1,231 @@
 use crate::{MacInfo, ResultType};
 use anyhow::bail;
-use std::mem;
-use winapi::shared::inaddr::IN_ADDR;
-use winapi::shared::winerror::ERROR_SUCCESS;
-use winapi::shared::ws2def::{AF_UNSPEC, SOCKADDR_IN};
-use winapi::um::iphlpapi::{GetAdaptersAddresses, GetBestInterface};
-use winapi::um::iptypes::{GAA_FLAG_INCLUDE_PREFIX, IP_ADAPTER_ADDRESSES_LH};
+use std::{ffi::OsString, mem, os::windows::ffi::OsStringExt, ptr, slice};
+use winapi::{
+    shared::{
+        inaddr::IN_ADDR,
+        ntdef::ULONG,
+        winerror::{ERROR_SUCCESS, NO_ERROR},
+        ws2def::{AF_UNSPEC, SOCKADDR_IN},
+    },
+    um::{
+        iphlpapi::{GetAdaptersAddresses, GetBestInterface},
+        iptypes::IP_ADAPTER_ADDRESSES_LH,
+    },
+};
+
+const GAA_FLAG_NONE: ULONG = 0x0000;
+const MAX_ADAPTERS: usize = 1024;
 
 pub fn get_mac() -> ResultType<MacInfo> {
+    let if_index = get_if_index()?;
+    let adapters = get_adapters()?;
+    // Safety: We don't use the pointer after `adapters` is dropped
+    let mut ptr = unsafe { adapters.ptr() };
+    let mut count = 0;
+
     unsafe {
-        // Use 8.8.8.8 (Google DNS) to get the default network adapter
-        let sock_addr = SOCKADDR_IN {
-            sin_family: AF_UNSPEC as u16,
-            sin_port: 0,
-            sin_addr: IN_ADDR {
-                S_un: mem::transmute(0x08080808u32),
-            }, // 8.8.8.8
-            sin_zero: [0; 8],
-        };
-        let mut if_index: u32 = 0;
+        loop {
+            if ptr.is_null() || count >= MAX_ADAPTERS {
+                break;
+            }
+            count += 1;
 
-        // Get the best interface index
-        if GetBestInterface(mem::transmute(sock_addr.sin_addr), &mut if_index) == ERROR_SUCCESS {
-            let mut buffer_length: u32 = 0;
+            #[cfg(not(target_pointer_width = "32"))]
+            let find = (*ptr).u.s().IfIndex == if_index;
+            #[cfg(target_pointer_width = "32")]
+            let find = ptr.read_unaligned().u.s().IfIndex == if_index;
 
-            // First call to get buffer size
-            let _result = GetAdaptersAddresses(
-                AF_UNSPEC as u32,
-                GAA_FLAG_INCLUDE_PREFIX,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-                &mut buffer_length,
-            );
+            if find {
+                let addr = convert_mac_bytes(ptr)?;
 
-            // Check if buffer_length is reasonable (prevent potential OOM)
-            if buffer_length == 0 || buffer_length > 1024 * 1024 {
-                bail!("Invalid buffer length received");
+                if !crate::is_valid_mac(&addr) {
+                    bail!("Invalid MAC address format: {}", addr);
+                }
+
+                #[cfg(not(target_pointer_width = "32"))]
+                let adapter_name = construct_string((*ptr).FriendlyName)?;
+                #[cfg(target_pointer_width = "32")]
+                let adapter_name = construct_string(ptr.read_unaligned().FriendlyName)?;
+                let name = adapter_name.to_string_lossy().to_string();
+
+                return Ok(MacInfo { name, addr });
             }
 
-            let mut buffer = vec![0u8; buffer_length as usize];
-            let addresses = buffer.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH;
-
-            if GetAdaptersAddresses(
-                AF_UNSPEC as u32,
-                GAA_FLAG_INCLUDE_PREFIX,
-                std::ptr::null_mut(),
-                addresses,
-                &mut buffer_length,
-            ) == ERROR_SUCCESS
+            // Otherwise go to the next device
+            #[cfg(target_pointer_width = "32")]
             {
-                let mut current_addresses = addresses;
-
-                while !current_addresses.is_null() {
-                    let adapter = &*current_addresses;
-
-                    if adapter.u.s().IfIndex == if_index {
-                        // Check if Description pointer is valid
-                        if adapter.Description.is_null() {
-                            bail!("Adapter description is null");
-                        }
-
-                        // Limit the maximum string length to prevent potential buffer overrun
-                        let desc_len = wcslen(adapter.Description).min(1024);
-
-                        let name = String::from_utf16_lossy(std::slice::from_raw_parts(
-                            adapter.Description,
-                            desc_len,
-                        ));
-
-                        // Validate PhysicalAddressLength
-                        if adapter.PhysicalAddressLength != 6 {
-                            bail!("Invalid MAC address length");
-                        }
-
-                        let mac = &adapter.PhysicalAddress[..6];
-                        let mac_string = format!(
-                            "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
-                            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
-                        );
-
-                        return Ok(MacInfo {
-                            name,
-                            addr: mac_string,
-                        });
-                    }
-                    // Validate Next pointer before continuing
-                    if current_addresses == adapter.Next {
-                        bail!("Circular linked list detected");
-                    }
-                    current_addresses = adapter.Next;
-                }
+                ptr = ptr.read_unaligned().Next;
+            }
+            #[cfg(not(target_pointer_width = "32"))]
+            {
+                ptr = (*ptr).Next;
             }
         }
+    }
+
+    bail!("no adapter found")
+}
+
+fn get_if_index() -> ResultType<u32> {
+    // Use 8.8.8.8 (Google DNS) to get the default network adapter
+    let sock_addr = SOCKADDR_IN {
+        sin_family: AF_UNSPEC as u16,
+        sin_port: 0,
+        sin_addr: IN_ADDR {
+            S_un: unsafe { mem::transmute(0x08080808u32) },
+        }, // 8.8.8.8
+        sin_zero: [0; 8],
+    };
+    let mut if_index: u32 = 0;
+
+    // Get the best interface index
+    let dst_addr = unsafe { mem::transmute(sock_addr.sin_addr) };
+    if unsafe { GetBestInterface(dst_addr, &mut if_index) } == NO_ERROR {
+        return Ok(if_index);
     }
     bail!("no adapter found")
 }
 
-fn wcslen(ptr: *const u16) -> usize {
-    let mut len = 0;
-    unsafe {
-        // Add maximum length check to prevent potential overflow
-        while len < 2048 && !ptr.add(len).is_null() && *ptr.add(len) != 0 {
-            len += 1;
+/// Copy over the 6 MAC address bytes to the buffer and format it as XX:XX:XX:XX:XX:XX.
+pub(crate) unsafe fn convert_mac_bytes(ptr: *mut IP_ADAPTER_ADDRESSES_LH) -> ResultType<String> {
+    if ptr.is_null() {
+        bail!("adapter pointer is null");
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    let (mac, length) = {
+        let adapter = ptr.read_unaligned();
+        (adapter.PhysicalAddress, adapter.PhysicalAddressLength)
+    };
+
+    #[cfg(not(target_pointer_width = "32"))]
+    let (mac, length) = {
+        let adapter = &*ptr;
+        (adapter.PhysicalAddress, adapter.PhysicalAddressLength)
+    };
+
+    if length != 6 {
+        bail!("invalid MAC address length");
+    }
+
+    Ok(format!(
+        "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+    ))
+}
+
+pub(crate) struct AdaptersList {
+    ptr: *mut IP_ADAPTER_ADDRESSES_LH,
+    size: usize,
+}
+
+impl AdaptersList {
+    /// Safety: The pointer returned by this method MUST NOT be used after
+    /// `self` has gone out of scope. This pointer may also be null.
+    pub(crate) unsafe fn ptr(&self) -> *mut IP_ADAPTER_ADDRESSES_LH {
+        self.ptr
+    }
+}
+
+impl Drop for AdaptersList {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() && self.size != 0 {
+            unsafe {
+                if let Ok(layout) = std::alloc::Layout::from_size_align(
+                    self.size,
+                    core::mem::align_of::<IP_ADAPTER_ADDRESSES_LH>(),
+                ) {
+                    std::alloc::dealloc(self.ptr as *mut u8, layout)
+                }
+            };
         }
     }
-    len
+}
+
+pub(crate) fn get_adapters() -> ResultType<AdaptersList> {
+    let mut buf_len = 0;
+
+    // This will get the number of bytes we need to allocate for all devices
+    unsafe {
+        GetAdaptersAddresses(
+            AF_UNSPEC as u32,
+            GAA_FLAG_NONE,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut buf_len,
+        );
+    }
+
+    // Add size check to prevent potential OOM
+    if buf_len == 0 || buf_len > 1024 * 1024 {  // 1MB limit
+        return Ok(AdaptersList {
+            ptr: ptr::null_mut(),
+            size: 0,
+        });
+    }
+
+    // Allocate `buf_len` bytes, and create a raw pointer to it with the correct alignment
+    // Safety:
+    let adapters_list: *mut IP_ADAPTER_ADDRESSES_LH = unsafe {
+        std::alloc::alloc(std::alloc::Layout::from_size_align(
+            usize::try_from(buf_len).map_err(|e| anyhow::anyhow!(e))?,
+            core::mem::align_of::<IP_ADAPTER_ADDRESSES_LH>(),
+        )?)
+    } as *mut IP_ADAPTER_ADDRESSES_LH;
+
+    // Get our list of adapters
+    let result = unsafe {
+        GetAdaptersAddresses(
+            // [IN] Family
+            AF_UNSPEC as u32,
+            // [IN] Flags
+            GAA_FLAG_NONE,
+            // [IN] Reserved
+            ptr::null_mut(),
+            // [INOUT] AdapterAddresses
+            adapters_list,
+            // [INOUT] SizePointer
+            &mut buf_len,
+        )
+    };
+
+    let adapters_list = AdaptersList {
+        ptr: adapters_list,
+        // Cast OK, we checked it above
+        size: buf_len as usize,
+    };
+
+    // Make sure we were successful
+    if result != ERROR_SUCCESS {
+        bail!("failed to get adapters");
+    }
+
+    Ok(adapters_list)
+}
+
+unsafe fn construct_string(ptr: *mut u16) -> ResultType<OsString> {
+    if ptr.is_null() {
+        bail!("ptr is null");
+    }
+    let slice = slice::from_raw_parts(ptr, get_null_position(ptr)?);
+    Ok(OsStringExt::from_wide(slice))
+}
+
+unsafe fn get_null_position(ptr: *mut u16) -> ResultType<usize> {
+    if ptr.is_null() {
+        bail!("ptr is null");
+    }
+
+    const MAX_LENGTH: isize = 2048;
+    for i in 0..MAX_LENGTH {
+        if ptr.offset(i).is_null() {
+            bail!("ptr is null");
+        }
+        if *ptr.offset(i) == 0 {
+            return Ok(i as usize);
+        }
+    }
+
+    bail!("string too long or no null terminator found")
 }


### PR DESCRIPTION
1. Using [mac_address](https://github.com/repnop/mac_address/blob/master/src/windows.rs)'s windows code to handle possible align issues on 32bit. In test,  both the old and the new i686 sciter version run ok on win7 32bit and win11 64bit.
2. Compatible with compilation of other platforms.
3. Force check the format of mac address

Tests:

windows:
![2efe80751e3ffe9cdfc1df7465b0c46](https://github.com/user-attachments/assets/8cf51da0-af3f-4bd3-9fde-20e9fa684e7f)

macos:
![bcad671d4f4accc593eae5830b80f37](https://github.com/user-attachments/assets/5fdad49e-e0c1-4842-bd59-861acbb6428b)

linux:
![2d9551c7e1b9ba11b8906f8e83884ea](https://github.com/user-attachments/assets/9aa21edf-26ce-4852-880f-6662e55b78b6)

